### PR TITLE
feat: build docker images in GitHub actions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/openfsd
+          images: ghcr.io/${{ github.repository_owner }}/openfsd-fsd
           tags: |
-            type=semver,pattern={{version}},prefix=v,suffix=-fsd
-            type=semver,pattern={{major}},prefix=v,suffix=-fsd
-            type=semver,pattern={{major}}.{{minor}},prefix=v,suffix=-fsd
-          flavor: |
-            latest=false
+            type=semver,pattern={{version}},prefix=v
+            type=semver,pattern={{major}},prefix=v
+            type=semver,pattern={{major}}.{{minor}},prefix=v
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -42,6 +40,8 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   build-web:
     runs-on: ubuntu-latest
@@ -56,13 +56,11 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/openfsd
+          images: ghcr.io/${{ github.repository_owner }}/openfsd-web
           tags: |
-            type=semver,pattern={{version}},prefix=v,suffix=-web
-            type=semver,pattern={{major}},prefix=v,suffix=-web
-            type=semver,pattern={{major}}.{{minor}},prefix=v,suffix=-web
-          flavor: |
-            latest=false
+            type=semver,pattern={{version}},prefix=v
+            type=semver,pattern={{major}},prefix=v
+            type=semver,pattern={{major}}.{{minor}},prefix=v
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -79,3 +77,5 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           tags: ${{ steps.meta.outputs.tags }}
           push: true
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,11 +19,14 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/openfsd-fsd
+          images: ghcr.io/${{ github.repository_owner }}/openfsd
           tags: |
-            type=semver,pattern={{version}},prefix=v
-            type=semver,pattern={{major}},prefix=v
-            type=semver,pattern={{major}}.{{minor}},prefix=v
+            type=semver,pattern={{version}},prefix=fsd-v
+            type=semver,pattern={{major}},prefix=fsd-v
+            type=semver,pattern={{major}}.{{minor}},prefix=fsd-v
+            type=raw,fsd-latest
+          flavor: |
+            latest=false
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -56,11 +59,14 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/${{ github.repository_owner }}/openfsd-web
+          images: ghcr.io/${{ github.repository_owner }}/openfsd
           tags: |
-            type=semver,pattern={{version}},prefix=v
-            type=semver,pattern={{major}},prefix=v
-            type=semver,pattern={{major}}.{{minor}},prefix=v
+            type=semver,pattern={{version}},prefix=web-v
+            type=semver,pattern={{major}},prefix=web-v
+            type=semver,pattern={{major}}.{{minor}},prefix=web-v
+            type=raw,web-latest
+          flavor: |
+            latest=false
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,75 @@
+name: Release
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-fsd:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/openfsd
+          tags: |
+            type=semver,pattern={{version}},prefix=v,suffix=-fsd
+            type=semver,pattern={{major}},prefix=v,suffix=-fsd
+            type=semver,pattern={{major}}.{{minor}},prefix=v,suffix=-fsd
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          file: Dockerfile.fsd
+          platforms: linux/amd64,linux/arm64
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ghcr.io/${{ github.repository_owner }}/openfsd
+
+  build-web:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository_owner }}/openfsd
+          tags: |
+            type=semver,pattern={{version}},prefix=v,suffix=-web
+            type=semver,pattern={{major}},prefix=v,suffix=-web
+            type=semver,pattern={{major}}.{{minor}},prefix=v,suffix=-web
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          file: Dockerfile.web
+          platforms: linux/amd64,linux/arm64
+          labels: ${{ steps.meta.outputs.labels }}
+          tags: ghcr.io/${{ github.repository_owner }}/openfsd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
             type=semver,pattern={{version}},prefix=v,suffix=-fsd
             type=semver,pattern={{major}},prefix=v,suffix=-fsd
             type=semver,pattern={{major}}.{{minor}},prefix=v,suffix=-fsd
+          flavor: |
+            latest=false
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -38,7 +40,7 @@ jobs:
           file: Dockerfile.fsd
           platforms: linux/amd64,linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
-          tags: ghcr.io/${{ github.repository_owner }}/openfsd
+          tags: ${{ steps.meta.outputs.tags }}
           push: true
 
   build-web:
@@ -59,6 +61,8 @@ jobs:
             type=semver,pattern={{version}},prefix=v,suffix=-web
             type=semver,pattern={{major}},prefix=v,suffix=-web
             type=semver,pattern={{major}}.{{minor}},prefix=v,suffix=-web
+          flavor: |
+            latest=false
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -73,5 +77,5 @@ jobs:
           file: Dockerfile.web
           platforms: linux/amd64,linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
-          tags: ghcr.io/${{ github.repository_owner }}/openfsd
+          tags: ${{ steps.meta.outputs.tags }}
           push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
           platforms: linux/amd64,linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
           tags: ghcr.io/${{ github.repository_owner }}/openfsd
+          push: true
 
   build-web:
     runs-on: ubuntu-latest
@@ -73,3 +74,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           labels: ${{ steps.meta.outputs.labels }}
           tags: ghcr.io/${{ github.repository_owner }}/openfsd
+          push: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
             type=semver,pattern={{version}},prefix=fsd-v
             type=semver,pattern={{major}},prefix=fsd-v
             type=semver,pattern={{major}}.{{minor}},prefix=fsd-v
-            type=raw,fsd-latest
+            type=raw,value=fsd-latest,enable=${{ !contains(github.ref, 'alpha') && !contains(github.ref, 'beta') }}
           flavor: |
             latest=false
 
@@ -64,7 +64,7 @@ jobs:
             type=semver,pattern={{version}},prefix=web-v
             type=semver,pattern={{major}},prefix=web-v
             type=semver,pattern={{major}}.{{minor}},prefix=web-v
-            type=raw,web-latest
+            type=raw,value=web-latest,enable=${{ !contains(github.ref, 'alpha') && !contains(github.ref, 'beta') }}
           flavor: |
             latest=false
 

--- a/Dockerfile.fsd
+++ b/Dockerfile.fsd
@@ -11,7 +11,9 @@ RUN go mod download
 # Build
 COPY . .
 
-RUN GO_ENABLED=0 go build -ldflags "-s -w" -o /go/bin/fsd
+ENV GOCACHE=/root/.cache/go-build
+ENV GO_ENABLED=0
+RUN --mount=type=cache,target="/root/.cache/go-build" go build -o /go/bin/fsd
 
 # Runner layer
 FROM alpine:latest

--- a/Dockerfile.fsd
+++ b/Dockerfile.fsd
@@ -1,5 +1,3 @@
-LABEL org.opencontainers.image.source=https://github.com/renorris/openfsd
-
 FROM golang:1.24 AS build
 
 WORKDIR /go/src/fsd

--- a/Dockerfile.fsd
+++ b/Dockerfile.fsd
@@ -1,17 +1,19 @@
+# Builder layer
 FROM golang:1.24 AS build
 
 WORKDIR /go/src/fsd
+
+# Download dependencies
 COPY go.mod go.sum ./
 
-# Cache module downloads
 RUN go mod download
 
+# Build
 COPY . .
 
-# Cache builds
-ENV GOCACHE=/root/.cache/go-build
-RUN --mount=type=cache,target="/root/.cache/go-build" CGO_ENABLED=0 go build -o /go/bin/fsd
+RUN GO_ENABLED=0 go build -ldflags "-s -w" -o /go/bin/fsd
 
+# Runner layer
 FROM alpine:latest
 
 RUN addgroup -g 2001 nonroot && \

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,19 +1,19 @@
+# Builder layer
 FROM golang:1.24 AS build
 
 WORKDIR /go/src/fsdweb
+
+# Download dependencies
 COPY go.mod go.sum ./
 
-# Cache module downloads
 RUN go mod download
 
+# Build
 COPY . .
 
-# Cache builds
-ENV GOCACHE=/root/.cache/go-build
-RUN --mount=type=cache,target="/root/.cache/go-build" \
-    cd web && \
-    CGO_ENABLED=0 go build -o /go/bin/fsdweb
+RUN cd web && CGO_ENABLED=0 go build -ldflags "-s -w" -o /go/bin/fsdweb
 
+# Runner layer
 FROM alpine:latest
 
 RUN addgroup -g 2001 nonroot && \

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,5 +1,3 @@
-LABEL org.opencontainers.image.source=https://github.com/renorris/openfsd
-
 FROM golang:1.24 AS build
 
 WORKDIR /go/src/fsdweb

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -11,7 +11,9 @@ RUN go mod download
 # Build
 COPY . .
 
-RUN cd web && CGO_ENABLED=0 go build -ldflags "-s -w" -o /go/bin/fsdweb
+ENV GOCACHE=/root/.cache/go-build
+ENV GO_ENABLED=0
+RUN --mount=type=cache,target="/root/.cache/go-build" cd web && go build -o /go/bin/fsdweb
 
 # Runner layer
 FROM alpine:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   fsd:
-    image: ghcr.io/renorris/openfsd:fsd-latest
+    image: ghcr.io/renorris/openfsd-fsd:latest
     restart: unless-stopped
     ports:
       - 6809:6809/tcp
@@ -11,7 +11,7 @@ services:
       - db:/db
 
   web:
-    image: ghcr.io/renorris/openfsd:web-latest
+    image: ghcr.io/renorris/openfsd-web:latest
     restart: unless-stopped
     ports:
       - 8000:8000/tcp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   fsd:
-    image: ghcr.io/renorris/openfsd-fsd:latest
+    image: ghcr.io/renorris/openfsd:fsd-latest
     restart: unless-stopped
     ports:
       - 6809:6809/tcp
@@ -11,7 +11,7 @@ services:
       - db:/db
 
   web:
-    image: ghcr.io/renorris/openfsd-web:latest
+    image: ghcr.io/renorris/openfsd:web-latest
     restart: unless-stopped
     ports:
       - 8000:8000/tcp

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,34 +2,24 @@ services:
   fsd:
     image: ghcr.io/renorris/openfsd:fsd-latest
     restart: unless-stopped
-    container_name: openfsd_fsd
-    hostname: openfsd_fsd
-    expose:
-      - "13618/tcp" # Internal HTTP REST API service. The webserver talks to this in order to obtain FSD state info.
     ports:
-      - "6809:6809/tcp"
+      - 6809:6809/tcp
     environment:
       DATABASE_SOURCE_NAME: /db/openfsd.db?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)
       DATABASE_AUTO_MIGRATE: true
     volumes:
-      - sqlite:/db
+      - db:/db
 
-  fsdweb:
+  web:
     image: ghcr.io/renorris/openfsd:web-latest
     restart: unless-stopped
-    container_name: openfsd_web
-    hostname: openfsd_web
     ports:
-      - "8000:8000/tcp"
+      - 8000:8000/tcp
     environment:
       DATABASE_SOURCE_NAME: /db/openfsd.db?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)
-      FSD_HTTP_SERVICE_ADDRESS: "http://openfsd_fsd:13618"
+      FSD_HTTP_SERVICE_ADDRESS: http://fsd:13618
     volumes:
-      - sqlite:/db
-
-networks:
-  openfsd:
-    name: openfsd_net
+      - db:/db
 
 volumes:
-  sqlite:
+  db:


### PR DESCRIPTION
Hello!

I recently stumbled upon this project and I am in love. While trying it out though I found some things that could be improved and one of them is building the docker images in GitHub actions. My guess is that you just do `docker build` locally which can be annoying and usually many people don't trust images not published by a CD job. In any case my pull request changes a couple of things. Firstly I simplified the docker compose file, the container name, hostname, expose and networks are not needed as docker will handle them. The frontend will be able to access the backend by just using `fsd` and docker DNS will route it correctly. Additionally I changed the dockerfiles to include Go flags to strip down the executables for smaller size and also remove the cache since it will be handled by the action (I also changed the naming to make it easier for editors to understand the file type and provide intellisense if any). Last but not least I added the action to build and push the web and FSD in two different images, this is because trying to use one image with multiple tags and versioning can get complex. With this system you will be able to create a release and provide a semver compatible tag and upon creating the release the action will publish the images. You can check out the result of the job in my [fork](https://github.com/steveiliop56/openfsd).

*P.S. The build can be painfully slow, around 8 minutes to build everything for both architectures, you can reduce this down to around 2 minutes by using native runners but then the workflow gets complex. I decided to start with a simple PR but if you are interested I can create a future one to include the more complex workflow.* 