### PR TITLE
fix: race-safe auth worker pool shutdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,11 +73,9 @@ jobs:
         with:
           images: ghcr.io/${{ github.repository }}
           tags: |
-            # Always publish branch tip tags; main also updates :latest.
+            # :latest is stable (main only). Dev pushes get :dev only — not :latest.
             type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
             type=raw,value=dev,enable=${{ github.ref == 'refs/heads/dev' }}
-            # While primary work is on dev, keep :latest in sync with dev too.
-            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/dev' }}
             type=sha,prefix=sha-
             type=ref,event=branch
             type=ref,event=pr

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Colocated mode (default) uses the shared DB and in-process service HTTP. For `-w
 
 Preferred for operators. See the [Deployment Wiki](https://github.com/renorris/openfsd/wiki/Deployment) (source: [`wiki/`](wiki/)).
 
-Images: **`ghcr.io/renorris/openfsd`** (`:latest`, `:dev`, `sha-*`) published by CI on every push to `main` and `dev`.
+Images: **`ghcr.io/renorris/openfsd`** — CI publishes `:latest` from **`main` only**, `:dev` from **`dev`** (unstable), plus `sha-*` / branch tags.
 
 **Upgrading from PostgreSQL?** Use [`openfsd-migrate-to-sqlite`](cmd/openfsd-migrate-to-sqlite) and [Migrating from PostgreSQL](wiki/Migrating-from-PostgreSQL.md). Optional multi-node: rqlite + mesh (`CLUSTER_ENABLED`, see [wiki/Deployment](wiki/Deployment.md) and `docs/design/distributed-openfsd.md`).
 

--- a/internal/server/auth_pool_test.go
+++ b/internal/server/auth_pool_test.go
@@ -1,0 +1,102 @@
+package server
+
+import (
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestTryAuthPool_ConcurrentWithShutdown ensures close/send on authPool cannot race.
+// Reproduces the CI failure: shutdownCluster closechan vs beginLogin send.
+func TestTryAuthPool_ConcurrentWithShutdown(t *testing.T) {
+	authCh := make(chan func(), 256)
+	s := &Server{
+		authPool: authCh,
+	}
+	s.authPoolWG.Add(2)
+	for i := 0; i < 2; i++ {
+		go func() {
+			defer s.authPoolWG.Done()
+			// Range the captured channel (mirrors New) so s.authPool = nil cannot race.
+			for fn := range authCh {
+				if fn != nil {
+					fn()
+				}
+			}
+		}()
+	}
+
+	var enqueued atomic.Int64
+	var closedHits atomic.Int64
+	var fullHits atomic.Int64
+	var ran atomic.Int64
+
+	const producers = 8
+	const perProducer = 200
+	var wg sync.WaitGroup
+	wg.Add(producers)
+	for p := 0; p < producers; p++ {
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perProducer; i++ {
+				ok, shut := s.tryAuthPool(func() { ran.Add(1) })
+				switch {
+				case ok:
+					enqueued.Add(1)
+				case shut:
+					closedHits.Add(1)
+				default:
+					fullHits.Add(1)
+				}
+			}
+		}()
+	}
+
+	// Let some work land, then shut down while producers still send.
+	time.Sleep(2 * time.Millisecond)
+	s.shutdownCluster()
+	wg.Wait()
+
+	if enqueued.Load()+closedHits.Load()+fullHits.Load() != producers*perProducer {
+		t.Fatalf("counts: enqueued=%d closed=%d full=%d", enqueued.Load(), closedHits.Load(), fullHits.Load())
+	}
+	// After shutdown, further tries must report closed.
+	ok, shut := s.tryAuthPool(func() {})
+	if ok || !shut {
+		t.Fatalf("after shutdown: enqueued=%v closed=%v want enqueued=false closed=true", ok, shut)
+	}
+	// Workers should have drained and exited.
+	done := make(chan struct{})
+	go func() {
+		s.authPoolWG.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("auth pool workers did not exit after shutdown")
+	}
+}
+
+func TestTryAuthPool_FullReturnsNotClosed(t *testing.T) {
+	s := &Server{
+		authPool: make(chan func(), 2),
+	}
+	// No workers — fill buffer.
+	if ok, shut := s.tryAuthPool(func() {}); !ok || shut {
+		t.Fatalf("first: ok=%v shut=%v", ok, shut)
+	}
+	if ok, shut := s.tryAuthPool(func() {}); !ok || shut {
+		t.Fatalf("second: ok=%v shut=%v", ok, shut)
+	}
+	ok, shut := s.tryAuthPool(func() {})
+	if ok || shut {
+		t.Fatalf("full: ok=%v shut=%v want false,false", ok, shut)
+	}
+	// Drain without closing via shutdown path: close under lock.
+	s.authMu.Lock()
+	close(s.authPool)
+	s.authPool = nil
+	s.authMu.Unlock()
+}

--- a/internal/server/gnet_fsd.go
+++ b/internal/server/gnet_fsd.go
@@ -397,8 +397,7 @@ func (e *fsdEngine) beginLogin(c gnet.Conn, cc *fsdConnCtx, idPacket, addPacket 
 
 	// Offload auth + ClaimReserve (PHASE A).
 	srv := e.srv
-	select {
-	case srv.authPool <- func() {
+	job := func() {
 		res := e.runAuthReserve(c, cc, client, token)
 		cc.mu.Lock()
 		if cc.closed {
@@ -422,8 +421,16 @@ func (e *fsdEngine) beginLogin(c gnet.Conn, cc *fsdConnCtx, idPacket, addPacket 
 			e.onAuthWake(gc)
 			return nil
 		})
-	}:
-	default:
+	}
+	enqueued, shutDown := srv.tryAuthPool(job)
+	if shutDown {
+		// Server shutting down — do not run auth inline.
+		if o := client.Outbound(); o != nil {
+			_ = o.Close()
+		}
+		return gnet.Close
+	}
+	if !enqueued {
 		// Pool full — run inline (still better than hanging forever).
 		res := e.runAuthReserve(c, cc, client, token)
 		cc.mu.Lock()
@@ -584,8 +591,7 @@ func (e *fsdEngine) finishAuthPending(c gnet.Conn, cc *fsdConnCtx) gnet.Action {
 		cc.mu.Lock()
 		cc.claimInFlight = true
 		cc.mu.Unlock()
-		select {
-		case e.srv.authPool <- func() {
+		job := func() {
 			ctx, cancel := context.WithTimeout(context.Background(), e.srv.mesh.ClaimTimeout())
 			defer cancel()
 			err := e.srv.mesh.ClaimCommit(ctx, cs, fence)
@@ -607,17 +613,27 @@ func (e *fsdEngine) finishAuthPending(c gnet.Conn, cc *fsdConnCtx) gnet.Action {
 				e.onAuthWake(gc)
 				return nil
 			})
-		}:
-			return gnet.None
-		default:
-			ctx, cancel := context.WithTimeout(context.Background(), e.srv.mesh.ClaimTimeout())
-			err := e.srv.mesh.ClaimCommit(ctx, cs, fence)
-			cancel()
+		}
+		enqueued, shutDown := e.srv.tryAuthPool(job)
+		if shutDown {
 			cc.mu.Lock()
 			cc.claimInFlight = false
 			cc.mu.Unlock()
-			return e.finishCommit(c, cc, &authJobResult{kind: "commit", commitOK: err == nil, commitErr: err})
+			e.srv.mesh.ClaimRelease(cs, fence)
+			e.srv.mesh.ClaimAbort(cs, fence)
+			return gnet.Close
 		}
+		if enqueued {
+			return gnet.None
+		}
+		// Pool full — run commit inline.
+		ctx, cancel := context.WithTimeout(context.Background(), e.srv.mesh.ClaimTimeout())
+		err := e.srv.mesh.ClaimCommit(ctx, cs, fence)
+		cancel()
+		cc.mu.Lock()
+		cc.claimInFlight = false
+		cc.mu.Unlock()
+		return e.finishCommit(c, cc, &authJobResult{kind: "commit", commitOK: err == nil, commitErr: err})
 	}
 
 	// Single-node: skip commit

--- a/internal/server/mesh_rpc.go
+++ b/internal/server/mesh_rpc.go
@@ -37,18 +37,15 @@ func (s *Server) meshHomeRPC(client *session.Session, callsign string, op cluste
 			onOK(resp)
 		}
 	}
-	if s.authPool == nil {
-		if onErr != nil {
-			onErr(cluster.ErrMeshNotStarted)
-		}
+	enqueued, shutDown := s.tryAuthPool(job)
+	if enqueued {
 		return
 	}
-	select {
-	case s.authPool <- job:
-		return
-	default:
-		// Fail closed — do not block gnet (R3-8).
-		if onErr != nil {
+	// Pool full or shut down — fail closed; do not block gnet (R3-8).
+	if onErr != nil {
+		if shutDown {
+			onErr(cluster.ErrMeshNotStarted)
+		} else {
 			onErr(cluster.ErrHomeRPCTimeout)
 		}
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -52,7 +52,9 @@ type Server struct {
 	// mesh is optional cluster fabric (nil when CLUSTER_ENABLED=false).
 	mesh cluster.Mesh
 	// authPool runs login auth + ClaimReserve + HomeRPC off the gnet loop.
+	// authMu guards close/nil of authPool vs concurrent tryAuthPool sends (race fix).
 	authPool   chan func()
+	authMu     sync.Mutex
 	authPoolWG sync.WaitGroup
 	// nodeID for online_users / datafeed (empty when single-node).
 	nodeID string
@@ -110,11 +112,13 @@ func New(d Deps) (*Server, error) {
 		nodeID:     d.Config.ClusterNodeID,
 	}
 	// Auth/HomeRPC worker pool (off gnet loop). Closed in shutdownCluster.
+	// Capture the channel in locals so workers never race with s.authPool = nil.
+	authCh := s.authPool
 	s.authPoolWG.Add(4)
 	for i := 0; i < 4; i++ {
 		go func() {
 			defer s.authPoolWG.Done()
-			for fn := range s.authPool {
+			for fn := range authCh {
 				if fn != nil {
 					fn()
 				}
@@ -351,10 +355,33 @@ func (s *Server) shutdownCluster() {
 	if s.mesh != nil {
 		_ = s.mesh.Stop()
 	}
-	if s.authPool != nil {
-		close(s.authPool)
+	// Close auth pool under authMu so concurrent tryAuthPool never sends on a closed channel.
+	s.authMu.Lock()
+	pool := s.authPool
+	s.authPool = nil
+	if pool != nil {
+		close(pool)
+	}
+	s.authMu.Unlock()
+	if pool != nil {
 		s.authPoolWG.Wait()
-		s.authPool = nil
+	}
+}
+
+// tryAuthPool enqueues fn on the auth worker pool.
+// Returns (true, false) if enqueued, (false, false) if the pool is full,
+// (false, true) if the pool is shut down. Concurrent-safe with shutdownCluster.
+func (s *Server) tryAuthPool(fn func()) (enqueued, closed bool) {
+	s.authMu.Lock()
+	defer s.authMu.Unlock()
+	if s.authPool == nil {
+		return false, true
+	}
+	select {
+	case s.authPool <- fn:
+		return true, false
+	default:
+		return false, false
 	}
 }
 

--- a/wiki/Deployment.md
+++ b/wiki/Deployment.md
@@ -27,7 +27,7 @@ docker compose up -d
 3. **Configure Server** — see [Configuration](Configuration.md)
 4. Connect a client — [Client Connection](Client-Connection.md)
 
-Images: **`ghcr.io/renorris/openfsd`** (`:latest`, `:dev`, `sha-*`) published by CI on pushes to `main` and `dev`.
+Images: **`ghcr.io/renorris/openfsd`** — CI publishes `:latest` from **`main` only**, `:dev` from **`dev`** (unstable), plus `sha-*` / branch tags.
 
 ### Service selection
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -23,5 +23,5 @@ Operator documentation for [openfsd](https://github.com/renorris/openfsd).
 
 ## Quick links
 
-- Images: `ghcr.io/renorris/openfsd` (`:latest`, `:dev`, `sha-*`)
+- Images: `ghcr.io/renorris/openfsd` (`:latest` = main, `:dev` = unstable tip, `sha-*`)
 - Protocol notes: repository `docs/`


### PR DESCRIPTION
## Summary

Fixes CI race failures on `dev` after the distributed mesh land ([run 30394892967](https://github.com/renorris/openfsd/actions/runs/30394892967)).

Also: stop tagging dev images as `:latest`; pin Node 24 / `setup-node@v7`.

**Merged via direct FF to `dev` at `a8cf860` (not via this PR merge button).**